### PR TITLE
Add rate-limit mitigation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,24 @@ python3 download_channel_videos.py \
   --cookies-from-browser chrome
 
 ```
+
+### Avoiding temporary rate limiting
+YouTube can temporarily block unauthenticated scraping when too many requests are made in a short period, or when the wrong
+player client is used. A few options have been added to help mitigate this:
+
+```bash
+python download_channel_videos.py \
+  --channels-file channels.txt \
+  --sleep-requests 1.5 \   # wait between HTTP requests
+  --sleep-interval 2 \     # random sleep between downloads (min)
+  --max-sleep-interval 5 \ # random sleep between downloads (max)
+  --youtube-client web \   # force the regular web client instead of TV
+  --cookies-from-browser chrome
+```
+
+Try the following when you begin to see `Video unavailable` messages or 429 HTTP errors:
+
+- **Use browser cookies** (`--cookies-from-browser chrome`) so requests look like a real logged-in session.
+- **Slow down the request rate** with the sleep options shown above.
+- **Force the `web` player client** via `--youtube-client web` to avoid the TV client that Google often rate limits.
+- If the limits persist, pause the script for a few hours and resume later (using `--archive` avoids re-downloading files).

--- a/download_channel_videos.py
+++ b/download_channel_videos.py
@@ -60,6 +60,30 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--skip-subtitles", action="store_true", help="Do not download subtitles/auto-captions")
     parser.add_argument("--skip-thumbs", action="store_true", help="Do not download thumbnails")
     parser.add_argument("--cookies-from-browser", default=None, help="Use cookies from your browser (chrome, safari, firefox, edge, etc.)")
+    parser.add_argument(
+        "--sleep-requests",
+        type=float,
+        default=None,
+        help="Seconds to sleep between HTTP requests (helps avoid rate limiting)",
+    )
+    parser.add_argument(
+        "--sleep-interval",
+        type=float,
+        default=None,
+        help="Minimum randomized sleep between video downloads",
+    )
+    parser.add_argument(
+        "--max-sleep-interval",
+        type=float,
+        default=None,
+        help="Maximum randomized sleep between video downloads",
+    )
+    parser.add_argument(
+        "--youtube-client",
+        choices=["web", "android", "ios", "tv"],
+        default=None,
+        help="Override the YouTube player client used by yt-dlp (default: yt-dlp decides)",
+    )
     return parser.parse_args()
 
 
@@ -108,6 +132,16 @@ def download_channel(url: str, args) -> None:
         ydl_opts["datebefore"] = ytdlp_date(args.until)
     if args.cookies_from_browser:
         ydl_opts["cookiesfrombrowser"] = (args.cookies_from_browser,)
+    if args.sleep_requests:
+        ydl_opts["sleep_interval_requests"] = args.sleep_requests
+    if args.sleep_interval:
+        ydl_opts["sleep_interval"] = args.sleep_interval
+    if args.max_sleep_interval:
+        ydl_opts["max_sleep_interval"] = args.max_sleep_interval
+    if args.youtube_client:
+        ydl_opts.setdefault("extractor_args", {})
+        ydl_opts["extractor_args"].setdefault("youtube", {})
+        ydl_opts["extractor_args"]["youtube"]["player_client"] = [args.youtube_client]
 
     downloaded_count = {"n": 0}
     max_total = args.max if isinstance(args.max, int) and args.max > 0 else None


### PR DESCRIPTION
## Summary
- add CLI options to control request throttling and YouTube client selection
- update README with troubleshooting guidance for rate limiting

## Testing
- python -m compileall download_channel_videos.py

------
https://chatgpt.com/codex/tasks/task_e_68d5771d7df0833397aefa977109469e