### PR TITLE
Support typed sources in channels list

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ python download_channel_videos.py \
   --cookies-from-browser chrome
 ```
 
-### Multiple channels (local channels.txt)
+### Multiple sources (local channels.txt)
 ```bash
 python download_channel_videos.py \
   --channels-file channels.txt \
@@ -28,7 +28,7 @@ python download_channel_videos.py \
   --cookies-from-browser chrome
 ```
 
-### Multiple channels (remote GitHub repo)
+### Multiple sources (remote GitHub repo)
 If your `channels.txt` is in a public GitHub repo, copy the **raw** link, e.g.:
 
 ```
@@ -82,3 +82,26 @@ The downloader now automatically retries with different YouTube player clients w
 - **Slow down the request rate** with the sleep options shown above.
 - **Force the `web` player client** via `--youtube-client web` to avoid the TV client that Google often rate limits.
 - If the limits persist, pause the script for a few hours and resume later (using `--archive` avoids re-downloading files).
+
+## channels.txt format tips
+
+- Lines beginning with `#` are ignored, which lets you organize related sources into sections.
+- Each non-comment line can optionally start with a prefix to specify the source type:
+  - `channel: https://www.youtube.com/@SomeCreator`
+  - `playlist: https://www.youtube.com/playlist?list=...`
+  - `video: https://www.youtube.com/watch?v=...`
+- If you omit the prefix the script assumes the entry is a channel and automatically fetches both the `/videos` and `/shorts`
+  tabs (unless you pass `--no-shorts`).
+
+Example:
+
+```
+# channels
+channel: https://www.youtube.com/@EricWTech
+
+# curated playlists
+playlist: https://www.youtube.com/playlist?list=PL01Ur3GaFSxyFumM3ywYF6MiJiOPpRdcA
+
+# favorite talks
+video: https://www.youtube.com/watch?v=Dif1hwBejCk
+```

--- a/channels.txt
+++ b/channels.txt
@@ -1,26 +1,26 @@
 # channels
-https://www.youtube.com/@EricWTech
-https://www.youtube.com/@indydevdan
-https://www.youtube.com/@buildnpublic
-https://www.youtube.com/@PeterYangYT
-https://www.youtube.com/@PatrickOakleyEllis
-https://www.youtube.com/@AddyOsmani
-https://www.youtube.com/@danielpinktv
-https://www.youtube.com/@TheFeatureCrew
-https://www.youtube.com/@Mark_Kashef
-https://www.youtube.com/@ThatNateBlack
-https://www.youtube.com/@TimRunia
-https://www.youtube.com/@GregIsenberg
-https://www.youtube.com/@SimonHoiberg
-https://www.youtube.com/@LowLevelTV
-https://www.youtube.com/@iamseankochel
-https://www.youtube.com/@AIOriented
-https://www.youtube.com/@aiunleashed509
-https://www.youtube.com/@CodieSanchezCT
-https://www.youtube.com/@DenDev
+channel: https://www.youtube.com/@EricWTech
+channel: https://www.youtube.com/@indydevdan
+channel: https://www.youtube.com/@buildnpublic
+channel: https://www.youtube.com/@PeterYangYT
+channel: https://www.youtube.com/@PatrickOakleyEllis
+channel: https://www.youtube.com/@AddyOsmani
+channel: https://www.youtube.com/@danielpinktv
+channel: https://www.youtube.com/@TheFeatureCrew
+channel: https://www.youtube.com/@Mark_Kashef
+channel: https://www.youtube.com/@ThatNateBlack
+channel: https://www.youtube.com/@TimRunia
+channel: https://www.youtube.com/@GregIsenberg
+channel: https://www.youtube.com/@SimonHoiberg
+channel: https://www.youtube.com/@LowLevelTV
+channel: https://www.youtube.com/@iamseankochel
+channel: https://www.youtube.com/@AIOriented
+channel: https://www.youtube.com/@aiunleashed509
+channel: https://www.youtube.com/@CodieSanchezCT
+channel: https://www.youtube.com/@DenDev
 
 #lists
-https://www.youtube.com/playlist?list=PL01Ur3GaFSxyFumM3ywYF6MiJiOPpRdcA
+playlist: https://www.youtube.com/playlist?list=PL01Ur3GaFSxyFumM3ywYF6MiJiOPpRdcA
 
 # videos
-https://www.youtube.com/watch?v=Dif1hwBejCk
+video: https://www.youtube.com/watch?v=Dif1hwBejCk


### PR DESCRIPTION
## Summary
- add a typed Source model so channels.txt entries can specify channel, playlist, or video targets
- update CLI handling, watcher logic, and logging to honor the new prefixes and default behavior
- document the format updates and refresh the example channels.txt with explicit source prefixes

## Testing
- python -m compileall download_channel_videos.py

------
https://chatgpt.com/codex/tasks/task_e_68da3326be348333850a160a3ff7c7aa