### PR TITLE
Expand DownloadLogger blocked message detection

### DIFF
--- a/download_channel_videos.py
+++ b/download_channel_videos.py
@@ -39,6 +39,30 @@ class DownloadAttempt:
 class DownloadLogger:
     """Custom logger that tracks repeated 'Video unavailable' errors."""
 
+    VIDEO_UNAVAILABLE_PATTERNS = (
+        "video unavailable",
+        "content isn't available",
+        "content is not available",
+        "available to members",
+        "members-only",
+        "join this channel to get access",
+        "age-restricted",
+        "sign in to confirm your age",
+        "not available in your country",
+        "not available in your location",
+        "unavailable in your country",
+        "blocked in your country",
+        "unavailable in your location",
+        "http error 403",
+        "403: forbidden",
+        "error 403",
+        "403 forbidden",
+        "http error 410",
+        "error 410",
+        "410: gone",
+        "410 gone",
+    )
+
     def __init__(self) -> None:
         self.video_unavailable_errors = 0
         self.other_errors = 0
@@ -64,7 +88,7 @@ class DownloadLogger:
     def error(self, message) -> None:
         text = self._ensure_text(message)
         lowered = text.lower()
-        if "video unavailable" in lowered or "content isn't available" in lowered or "content is not available" in lowered:
+        if any(pattern in lowered for pattern in self.VIDEO_UNAVAILABLE_PATTERNS):
             self.video_unavailable_errors += 1
         else:
             self.other_errors += 1

--- a/tests/test_download_logger.py
+++ b/tests/test_download_logger.py
@@ -1,0 +1,39 @@
+import sys
+import types
+import unittest
+
+
+if "yt_dlp" not in sys.modules:
+    sys.modules["yt_dlp"] = types.SimpleNamespace()
+
+from download_channel_videos import DownloadLogger
+
+
+class DownloadLoggerTests(unittest.TestCase):
+    def test_known_video_unavailable_messages(self):
+        logger = DownloadLogger()
+        messages = [
+            "Video unavailable",
+            "This video is available to members only",
+            "This content isn't available in your country",
+            "HTTP Error 403: Forbidden",
+            "HTTP Error 410: Gone",
+            "Sign in to confirm your age",
+        ]
+
+        for message in messages:
+            logger.error(message)
+
+        self.assertEqual(len(messages), logger.video_unavailable_errors)
+        self.assertEqual(0, logger.other_errors)
+
+    def test_other_errors_tracked_separately(self):
+        logger = DownloadLogger()
+        logger.error("Unexpected network failure")
+
+        self.assertEqual(0, logger.video_unavailable_errors)
+        self.assertEqual(1, logger.other_errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- expand the DownloadLogger video-unavailable detection to cover additional block messages such as members-only, age restrictions, regional locks, and HTTP 403/410 responses
- add unit tests to ensure the logger counts the new blocked phrases and keeps other errors separate

## Testing
- python -m unittest discover -s tests -v

------
https://chatgpt.com/codex/tasks/task_e_68dbdac0a27083338fff6712753fde6c