### PR TITLE
Handle remote channel list fetch errors

### DIFF
--- a/download_channel_videos.py
+++ b/download_channel_videos.py
@@ -15,6 +15,7 @@ import os
 import sys
 import re
 import urllib.request
+import urllib.error
 import time
 from dataclasses import dataclass
 from datetime import datetime
@@ -344,8 +345,12 @@ def download_source(source: Source, args) -> None:
 
 def load_sources_from_url(url: str) -> List[Source]:
     print(f"\nFetching source list from {url} ...")
-    with urllib.request.urlopen(url) as response:
-        data = response.read().decode("utf-8")
+    try:
+        with urllib.request.urlopen(url) as response:
+            data = response.read().decode("utf-8")
+    except (urllib.error.HTTPError, urllib.error.URLError, UnicodeDecodeError) as exc:
+        print(f"Failed to fetch source list from {url}: {exc}", file=sys.stderr)
+        return []
     sources: List[Source] = []
     for idx, line in enumerate(data.splitlines(), start=1):
         stripped = line.strip()


### PR DESCRIPTION
## Summary
- guard remote channel list fetching with error handling so network issues are reported without crashing

## Testing
- python download_channel_videos.py --channels-url http://invalid.example

------
https://chatgpt.com/codex/tasks/task_e_68dbdad9e5348333bc85a7c1780020d1