### PR TITLE
Handle inline comments in parse_source_line

### DIFF
--- a/download_channel_videos.py
+++ b/download_channel_videos.py
@@ -145,6 +145,12 @@ def parse_source_line(line: str) -> Optional[Source]:
     if not stripped or stripped.startswith("#"):
         return None
 
+    comment_match = re.search(r"\s#", stripped)
+    if comment_match:
+        stripped = stripped[: comment_match.start()].rstrip()
+        if not stripped:
+            return None
+
     prefix_map = {
         "channel": SourceType.CHANNEL,
         "channels": SourceType.CHANNEL,

--- a/tests/test_parse_source_line.py
+++ b/tests/test_parse_source_line.py
@@ -1,0 +1,45 @@
+"""Focused tests for inline comment handling in parse_source_line."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import download_channel_videos as dc
+
+
+@pytest.mark.parametrize(
+    "raw, expected_kind, expected_url",
+    [
+        ("https://example.com # trailing", dc.SourceType.CHANNEL, "https://example.com"),
+        (
+            "https://example.com/watch?v=1#fragment # keep fragment",
+            dc.SourceType.CHANNEL,
+            "https://example.com/watch?v=1#fragment",
+        ),
+        (
+            "playlist: https://example.com/list # playlist comment",
+            dc.SourceType.PLAYLIST,
+            "https://example.com/list",
+        ),
+        (
+            "playlist: https://example.com/list#frag # keep",
+            dc.SourceType.PLAYLIST,
+            "https://example.com/list#frag",
+        ),
+    ],
+)
+def test_parse_source_line_strips_inline_comments(raw, expected_kind, expected_url):
+    source = dc.parse_source_line(raw)
+    assert source is not None
+    assert source.kind is expected_kind
+    assert source.url == expected_url
+
+
+def test_parse_source_line_missing_url_after_comment():
+    with pytest.raises(ValueError):
+        dc.parse_source_line("channel:    # comment only")


### PR DESCRIPTION
## Summary
- strip inline comments preceded by whitespace before parsing channels.txt lines
- ensure prefix parsing still errors when only comments remain
- add coverage for inline comment scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbe9afe78083338fab9795c1ebec04