### PR TITLE
Fix shorts tab duplication when building channel download URLs

### DIFF
--- a/download_channel_videos.py
+++ b/download_channel_videos.py
@@ -136,13 +136,17 @@ class Source:
 
         if self.kind is SourceType.CHANNEL:
             urls: List[str]
-            if re.search(r"/(videos|shorts|streams|live)$", normalized):
+            base_channel_url = normalized
+            trailing_match = re.search(r"/(videos|shorts|streams|live)$", normalized)
+
+            if trailing_match:
                 urls = [normalized]
+                base_channel_url = normalized[: -len(trailing_match.group(0))]
             else:
                 urls = [normalized + "/videos"]
 
             if include_shorts:
-                shorts_url = normalized + "/shorts"
+                shorts_url = base_channel_url + "/shorts"
                 if shorts_url not in urls:
                     urls.append(shorts_url)
             return urls

--- a/tests/test_build_download_urls.py
+++ b/tests/test_build_download_urls.py
@@ -1,0 +1,27 @@
+from download_channel_videos import Source, SourceType
+
+
+def test_channel_url_expands_to_videos_and_shorts():
+    source = Source(SourceType.CHANNEL, "https://www.youtube.com/@example")
+
+    assert source.build_download_urls() == [
+        "https://www.youtube.com/@example/videos",
+        "https://www.youtube.com/@example/shorts",
+    ]
+
+
+def test_channel_url_with_existing_tab_does_not_duplicate_tab():
+    source = Source(SourceType.CHANNEL, "https://www.youtube.com/@example/shorts")
+
+    assert source.build_download_urls() == [
+        "https://www.youtube.com/@example/shorts",
+    ]
+
+
+def test_channel_url_with_existing_tab_keeps_other_tab_unique():
+    source = Source(SourceType.CHANNEL, "https://www.youtube.com/@example/videos")
+
+    assert source.build_download_urls() == [
+        "https://www.youtube.com/@example/videos",
+        "https://www.youtube.com/@example/shorts",
+    ]


### PR DESCRIPTION
## Summary
- avoid appending an extra `/shorts` segment when a channel URL already targets a specific tab
- ensure the shorts tab is still added once for base channel URLs by using the base channel path
- add regression coverage for channel URL expansion scenarios

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc2802cabc83339512ee46c6d5d108