### PR TITLE
Handle retryable 403 errors and add targeted retries

### DIFF
--- a/tests/test_build_download_urls.py
+++ b/tests/test_build_download_urls.py
@@ -1,3 +1,8 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
 from download_channel_videos import Source, SourceType
 
 

--- a/tests/test_match_filters.py
+++ b/tests/test_match_filters.py
@@ -103,3 +103,16 @@ def test_download_logger_classification(message: str, expected: str) -> None:
     else:
         assert logger.video_unavailable_errors == 0
         assert logger.other_errors == 2
+
+
+def test_download_logger_retryable_errors() -> None:
+    logger = dc.DownloadLogger()
+    logger.set_video("abc123def45")
+    logger.error("HTTP Error 403: Forbidden")
+    assert logger.retryable_error_ids == {"abc123def45"}
+    assert logger.other_errors == 0
+
+    logger.set_video("abc123def45")
+    logger.record_exception(RuntimeError("HTTP Error 403: Forbidden"))
+    assert logger.retryable_error_ids == {"abc123def45"}
+    assert logger.other_errors == 0

--- a/tests/test_retryable_retries.py
+++ b/tests/test_retryable_retries.py
@@ -1,0 +1,87 @@
+"""Tests for retryable HTTP 403 handling in download_source."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import download_channel_videos as dc
+
+
+def make_args(**overrides):
+    defaults = {
+        "output": "downloads",
+        "skip_thumbs": False,
+        "skip_subtitles": False,
+        "archive": None,
+        "rate_limit": None,
+        "concurrency": None,
+        "since": None,
+        "until": None,
+        "cookies_from_browser": None,
+        "sleep_requests": None,
+        "sleep_interval": None,
+        "max_sleep_interval": None,
+        "allow_restricted": False,
+        "youtube_client": None,
+        "no_shorts": False,
+        "max": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_download_source_retries_next_client_on_retryable(monkeypatch: pytest.MonkeyPatch) -> None:
+    source = dc.Source(dc.SourceType.CHANNEL, "https://www.youtube.com/@Example")
+    args = make_args()
+
+    calls = []
+
+    def fake_run_download_attempt(
+        urls,
+        args_,
+        client,
+        max_total,
+        downloaded_ids,
+        target_video_ids=None,
+    ):
+        calls.append(
+            {
+                "client": client,
+                "urls": tuple(urls),
+                "target_video_ids": None if target_video_ids is None else set(target_video_ids),
+            }
+        )
+        if len(calls) == 1:
+            assert target_video_ids is None
+            return dc.DownloadAttempt(
+                downloaded=0,
+                video_unavailable_errors=0,
+                other_errors=0,
+                retryable_error_ids={"retry-id"},
+                stopped_due_to_limit=False,
+            )
+
+        assert target_video_ids == {"retry-id"}
+        downloaded_ids.add("retry-id")
+        return dc.DownloadAttempt(
+            downloaded=1,
+            video_unavailable_errors=0,
+            other_errors=0,
+            retryable_error_ids=set(),
+            stopped_due_to_limit=False,
+        )
+
+    monkeypatch.setattr(dc, "run_download_attempt", fake_run_download_attempt)
+
+    dc.download_source(source, args)
+
+    assert len(calls) == 2
+    assert calls[0]["client"] == "web"
+    assert calls[1]["client"] == "android"
+    assert calls[1]["target_video_ids"] == {"retry-id"}


### PR DESCRIPTION
## Summary
- detect retryable HTTP 403 errors, retain the affected video IDs, and expose them via `DownloadAttempt`
- retry only the failed IDs on subsequent player clients while updating attempt summaries
- cover the new behavior with unit tests and ensure tests import the main module reliably

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc35c40ea88333857a6918493d5eff