### PR TITLE
Add automatic authentication defaults and client retry improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ The downloader now automatically retries with different YouTube player clients w
   CLIENT.CONTEXT+TOKEN` when integrating an external provider.
 - If the limits persist, pause the script for a few hours and resume later (using `--archive` avoids re-downloading files).
 
+### Automatic authentication defaults
+
+If you routinely run the script with the same authentication details you can configure them once via environment
+variables:
+
+| Environment variable | Purpose |
+| --- | --- |
+| `YOUTUBE_SCRAPER_COOKIES_FROM_BROWSER` | Browser profile to pull cookies from (e.g. `chrome`, `firefox`). |
+| `YOUTUBE_SCRAPER_PO_TOKENS` | Comma or newline separated list of PO tokens in `CLIENT.CONTEXT+TOKEN` format. |
+| `YOUTUBE_SCRAPER_FETCH_PO_TOKEN` | Overrides yt-dlp's PO token fetch behavior (`auto`, `always`, or `never`). |
+
+When these variables are present the script automatically applies them to every invocation, so the required PO token and
+cookies are always provided even if you omit the corresponding command-line options. By default the downloader now also
+requests PO tokens proactively (`--youtube-fetch-po-token always`) to avoid integrity challenges on the first client
+attempt.
+
 ## channels.txt format tips
 
 - Lines beginning with `#` are ignored, which lets you organize related sources into sections.

--- a/tests/test_auth_defaults.py
+++ b/tests/test_auth_defaults.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import download_channel_videos as dc
+
+
+def make_args(**overrides):
+    defaults = {
+        "cookies_from_browser": None,
+        "youtube_po_token": [],
+        "youtube_fetch_po_token": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_env_defaults_populate_missing_fields():
+    args = make_args()
+    env = {
+        dc.ENV_COOKIES_FROM_BROWSER: "chrome",
+        dc.ENV_PO_TOKENS: "web.web+abc123,ios.ios+def456\nweb.web+abc123",
+        dc.ENV_FETCH_PO_TOKEN: "never",
+    }
+
+    dc.apply_authentication_defaults(args, environ=env)
+
+    assert args.cookies_from_browser == "chrome"
+    assert args.youtube_po_token == ["web.web+abc123", "ios.ios+def456"]
+    assert args.youtube_fetch_po_token == "never"
+
+
+def test_cli_values_take_precedence_over_env():
+    args = make_args(
+        cookies_from_browser="firefox",
+        youtube_po_token=["android.context+123"],
+        youtube_fetch_po_token="auto",
+    )
+    env = {
+        dc.ENV_COOKIES_FROM_BROWSER: "chrome",
+        dc.ENV_PO_TOKENS: "ios.context+456",
+        dc.ENV_FETCH_PO_TOKEN: "never",
+    }
+
+    dc.apply_authentication_defaults(args, environ=env)
+
+    assert args.cookies_from_browser == "firefox"
+    assert args.youtube_po_token == ["android.context+123", "ios.context+456"]
+    assert args.youtube_fetch_po_token == "auto"


### PR DESCRIPTION
## Summary
- load cookies, PO tokens, and fetch behavior from environment variables so they are provided automatically
- force proactive PO token fetching by default and improve client cycling when requests fail
- expand tests covering authentication defaults and retry logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc428058688333a4d44309d829eeef