### PR TITLE
Fix summary video counts with metadata scan

### DIFF
--- a/tests/test_retryable_retries.py
+++ b/tests/test_retryable_retries.py
@@ -46,6 +46,7 @@ def test_download_source_retries_next_client_on_retryable(monkeypatch: pytest.Mo
     args = make_args()
 
     monkeypatch.setattr(dc, "DEFAULT_PLAYER_CLIENTS", ("tv", "web_safari"))
+    monkeypatch.setattr(dc, "collect_all_video_ids", lambda *a, **k: set())
 
     calls = []
 
@@ -99,6 +100,7 @@ def test_download_source_cycles_on_other_errors(monkeypatch: pytest.MonkeyPatch)
     args = make_args()
 
     monkeypatch.setattr(dc, "DEFAULT_PLAYER_CLIENTS", ("tv", "web_safari"))
+    monkeypatch.setattr(dc, "collect_all_video_ids", lambda *a, **k: set())
 
     calls = []
 
@@ -145,6 +147,7 @@ def test_download_source_retries_after_unavailable(monkeypatch: pytest.MonkeyPat
     args = make_args()
 
     monkeypatch.setattr(dc, "DEFAULT_PLAYER_CLIENTS", ("tv", "web_safari"))
+    monkeypatch.setattr(dc, "collect_all_video_ids", lambda *a, **k: set())
 
     calls = []
 
@@ -191,6 +194,7 @@ def test_download_source_prints_summary(monkeypatch: pytest.MonkeyPatch, capsys)
     args = make_args()
 
     monkeypatch.setattr(dc, "DEFAULT_PLAYER_CLIENTS", ("tv", "web_safari"))
+    monkeypatch.setattr(dc, "collect_all_video_ids", lambda *a, **k: {"vid1", "vid2", "vid3"})
 
     def fake_run_download_attempt(
         urls,
@@ -231,6 +235,8 @@ def test_download_source_cycles_after_user_selected_client(monkeypatch: pytest.M
     source = dc.Source(dc.SourceType.CHANNEL, "https://www.youtube.com/@Example")
     primary = dc.DEFAULT_PLAYER_CLIENTS[-1]
     args = make_args(youtube_client=primary)
+
+    monkeypatch.setattr(dc, "collect_all_video_ids", lambda *a, **k: set())
 
     calls = []
 

--- a/tests/test_video_detection.py
+++ b/tests/test_video_detection.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import re
+from types import SimpleNamespace
+
+import pytest
+
+import download_channel_videos as dc
+
+
+def make_args(**overrides):
+    defaults = {
+        "output": "downloads",
+        "skip_thumbs": False,
+        "skip_subtitles": False,
+        "archive": "archive.txt",
+        "rate_limit": None,
+        "concurrency": None,
+        "since": None,
+        "until": None,
+        "cookies_from_browser": None,
+        "sleep_requests": None,
+        "sleep_interval": None,
+        "max_sleep_interval": None,
+        "allow_restricted": False,
+        "youtube_client": None,
+        "youtube_fetch_po_token": None,
+        "youtube_po_token": [],
+        "youtube_player_params": None,
+        "no_shorts": False,
+        "max": None,
+    }
+    defaults.update(overrides)
+    args = SimpleNamespace(**defaults)
+    dc.apply_authentication_defaults(args, environ={})
+    return args
+
+
+def test_collect_video_ids_from_info_handles_nested_entries() -> None:
+    info = {
+        "_type": "playlist",
+        "entries": [
+            {"id": "video-1"},
+            {"_type": "playlist", "entries": [{"id": "video-2"}, None]},
+            None,
+            {"_type": "url", "entries": [{"id": "video-3"}]},
+        ],
+    }
+
+    dest: set[str] = set()
+    dc._collect_video_ids_from_info(info, dest)
+
+    assert dest == {"video-1", "video-2", "video-3"}
+
+
+def test_collect_all_video_ids_uses_metadata_without_archive(monkeypatch: pytest.MonkeyPatch) -> None:
+    args = make_args()
+    captured_opts = {}
+
+    class DummyYDL:
+        def __init__(self, opts):
+            captured_opts.update(opts)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def extract_info(self, url, download=False):
+            assert download is False
+            return {"_type": "playlist", "entries": [{"id": "a"}, {"id": "b"}]}
+
+    monkeypatch.setattr(dc.yt_dlp, "YoutubeDL", DummyYDL)
+
+    ids = dc.collect_all_video_ids(["https://example.com/channel"], args, None)
+
+    assert ids == {"a", "b"}
+    assert captured_opts["skip_download"] is True
+    assert captured_opts["progress_hooks"] == []
+    assert "download_archive" not in captured_opts
+    assert "match_filter" not in captured_opts
+
+
+def test_download_source_summary_includes_metadata_count(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source = dc.Source(dc.SourceType.CHANNEL, "https://www.youtube.com/@Example")
+    args = make_args()
+
+    monkeypatch.setattr(dc, "DEFAULT_PLAYER_CLIENTS", ("tv",))
+    monkeypatch.setattr(dc, "collect_all_video_ids", lambda *a, **k: {"one", "two", "three"})
+
+    def fake_run(*_a, **_kw):
+        return dc.DownloadAttempt(
+            downloaded=0,
+            video_unavailable_errors=0,
+            other_errors=0,
+            detected_video_ids=set(),
+            downloaded_video_ids=set(),
+            retryable_error_ids=set(),
+            stopped_due_to_limit=False,
+        )
+
+    monkeypatch.setattr(dc, "run_download_attempt", fake_run)
+
+    dc.download_source(source, args)
+
+    out = capsys.readouterr().out
+    cleaned = re.sub(r"\x1b\[[0-9;]*m", "", out)
+    match = re.search(r"Total videos detected:\s*(\d+)", cleaned)
+    assert match
+    assert match.group(1) == "3"


### PR DESCRIPTION
## Summary
- add a metadata scan that gathers every video id for a source before downloads so the summary reflects all videos
- add helpers and unit tests for the metadata extraction and adjust existing retry tests to stub the new behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd11cd53bc833386434dfeefa6d127