### PR TITLE
Fix client failure limit switching and improve logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ The downloader now automatically retries with different YouTube player clients w
   CLIENT.CONTEXT+TOKEN` when integrating an external provider.
 - If the limits persist, pause the script for a few hours and resume later (using `--archive` avoids re-downloading files).
 
+### Preserving original formats
+
+The downloader now relies on yt-dlp's native format selection so videos are saved in whatever container YouTube provides.
+If you need to override the selection you can pass a custom `--format` expression or request a specific merged container via
+`--merge-output-format`, both of which are forwarded directly to yt-dlp.
+
 ### Automatic authentication defaults
 
 If you routinely run the script with the same authentication details you can configure them once via environment


### PR DESCRIPTION
## Summary
- count every download failure so the next client is tried after five unsuccessful attempts
- add prominent banners and per-URL context so logs clearly identify the active YouTube client
- add regression test that simulates repeated failures and asserts the threshold is enforced

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd1dcd88ec83339fad4300a5570f3d